### PR TITLE
Fix an issue that prevented stored value from being repopulated

### DIFF
--- a/taxonomy.php
+++ b/taxonomy.php
@@ -80,7 +80,7 @@ class cfs_taxonomy extends cfs_field
         } else {
             wp_dropdown_categories(
                 array(
-                    'selected'         => $field->value[0],
+                    'selected'         => $field->value,
                     'taxonomy'         => $taxonomy_name,
                     'hide_empty'       => 0,
                     'name'             => $field->input_name,


### PR DESCRIPTION
$field->value is not an array so the saved value was not being properly restored when editing the Field Group (but it was being saved to the database properly)
